### PR TITLE
AC: fixed enum Rotation

### DIFF
--- a/src/ch/epfl/chacun/Rotation.java
+++ b/src/ch/epfl/chacun/Rotation.java
@@ -36,12 +36,13 @@ public enum Rotation {
     /**
      * Negation de la rotation
      *
-     * @return ALL.get(indexNegate)
-     *      la rotation inverse a this
+     * @return negationRotation
+     *          rotation négative par rapport à la rotation initiale
      */
     public Rotation negated() {
-        int indexNegate = (ordinal() + 2)%4;
-        return ALL.get(indexNegate);
+        int negationIndex = (4 - ordinal()) % COUNT;
+        Rotation negationRotation = ALL.get(negationIndex);
+        return negationRotation;
     }
 
     /**


### PR DESCRIPTION
La méthode negation() a été fix :
 - NONE = NONE.negation()
 - HALF_TURN = HALF_TURN.negation()