### PR TITLE
AC: fixed enum Direction

### DIFF
--- a/src/ch/epfl/chacun/Direction.java
+++ b/src/ch/epfl/chacun/Direction.java
@@ -29,7 +29,7 @@ public enum Direction {
      */
     public Direction rotated(Rotation rotation) {
         Direction rotatedDirection;
-        int rotatedDirectionIndex = ordinal() + rotation.quarterTurnsCW();
+        int rotatedDirectionIndex = (ordinal() + rotation.quarterTurnsCW()) % COUNT;
         rotatedDirection = ALL.get(rotatedDirectionIndex);
         return rotatedDirection;
     }


### PR DESCRIPTION
Fixed error where LEFT rotations didn't work.
Added a COUNT modula to make sure no rotation sum would exceed 4, and ensure proper index position in List ALL.