### PR TITLE
fixed cancelling deer with hunting trap

### DIFF
--- a/src/ch/epfl/chacun/GameState.java
+++ b/src/ch/epfl/chacun/GameState.java
@@ -268,9 +268,7 @@ public record GameState(
                         updatedMessageBoard = updatedMessageBoard.withScoredHuntingTrap(scorer, adjacentMeadow,
                                 cancelledAnimals);
                         // Annule tous les animaux du plateau de jeu, y compris les cerfs "mangés"
-                        animals.stream()
-                                .filter(animal -> !cancelledAnimals.contains(animal))
-                                .forEach(cancelledAnimals::add);
+                        cancelledAnimals.addAll(animals);
                         updatedBoard = updatedBoard.withMoreCancelledAnimals(cancelledAnimals);
                     }
                 }


### PR DESCRIPTION
Now we make sure we're not recancelling any deer or whatever the problem really was (I just added a bunch of conditions to stop people from eating the same deer twice).