### PR TITLE
fixed occupant icons being under markers (now they're above)

### DIFF
--- a/src/ch/epfl/chacun/gui/BoardUI.java
+++ b/src/ch/epfl/chacun/gui/BoardUI.java
@@ -182,6 +182,7 @@ public class BoardUI {
                         group.getChildren().add(cancellationToken);
                     }));
 
+                    // Gérer les jetons des occupants
                     if (newValue.kind() != Tile.Kind.START) {
                         PlayerColor placer = tile.getValue().placer();
                         for (Occupant occupant : newValue.potentialOccupants()) {


### PR DESCRIPTION
![image](https://github.com/LimeeFox/ChaCuN/assets/50243381/ac25aba9-1f7a-42c1-a7a7-d6a6927f4ba1)

